### PR TITLE
Fix filter bar lag

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,5 +2,5 @@ import { type Database, Constants } from "@/database.types";
 
 export type Switch = Database["public"]["Tables"]["switches"]["Row"];
 
-export const Types = Constants.public.Enums.Type;
-export const TypesNoUnknown = Types.filter((t) => t !== "Unknown");
+export const SwitchTypes = Constants.public.Enums.Type;
+export const SwitchTypesNoUnknown = SwitchTypes.filter((t) => t !== "Unknown");


### PR DESCRIPTION
# Fix filter bar lag

Closes #12

Switched the filter bar to keep the state of the checkboxes and just use the search params for the initial state.

This helps make the filter bar feel more snappy since we're not waiting for the query response.

This _could_ lead to the filter bar being out of sync with the server...

### Changelog

- **rename Types -> SwitchTypes**
- **make the filterbar checkboxes client optimistic**
